### PR TITLE
Fix default pulse routing keys

### DIFF
--- a/fennec_aurora_task_creator/config.py
+++ b/fennec_aurora_task_creator/config.py
@@ -60,8 +60,8 @@ KEYS_AND_DEFAULT_VALUES = (
         'default_value': [{
             'path': 'exchange/taskcluster-queue/v1/task-completed',
             'routing_keys': [
-                'route.index.gecko.v2.mozilla-aurora.latest.mobile-l10n.android-api-15-opt.multi#',
-                'route.index.gecko.v2.mozilla-aurora.latest.mobile-l10n.android-x86-opt.multi#',
+                'route.index.gecko.v2.mozilla-aurora.latest.mobile-l10n.android-api-15-opt.multi',
+                'route.index.gecko.v2.mozilla-aurora.latest.mobile-l10n.android-x86-opt.multi',
             ],
         }],
         'is_flat': False

--- a/fennec_aurora_task_creator/test/test_config.py
+++ b/fennec_aurora_task_creator/test/test_config.py
@@ -57,8 +57,8 @@ DEFAULT_PROVIDED_CONFIG = {
         'exchanges': [{
             'path': 'exchange/taskcluster-queue/v1/task-completed',
             'routing_keys': [
-                'route.index.gecko.v2.mozilla-aurora.latest.mobile-l10n.android-api-15-opt.multi#',
-                'route.index.gecko.v2.mozilla-aurora.latest.mobile-l10n.android-x86-opt.multi#',
+                'route.index.gecko.v2.mozilla-aurora.latest.mobile-l10n.android-api-15-opt.multi',
+                'route.index.gecko.v2.mozilla-aurora.latest.mobile-l10n.android-x86-opt.multi',
             ]
         }],
     },
@@ -155,8 +155,8 @@ def test_generate_final_config_object_fulfills_default_values():
     assert final_config['pulse']['exchanges'] == [{
         'path': 'exchange/taskcluster-queue/v1/task-completed',
         'routing_keys': [
-            'route.index.gecko.v2.mozilla-aurora.latest.mobile-l10n.android-api-15-opt.multi#',
-            'route.index.gecko.v2.mozilla-aurora.latest.mobile-l10n.android-x86-opt.multi#'
+            'route.index.gecko.v2.mozilla-aurora.latest.mobile-l10n.android-api-15-opt.multi',
+            'route.index.gecko.v2.mozilla-aurora.latest.mobile-l10n.android-x86-opt.multi'
         ],
     }]
 


### PR DESCRIPTION
Following up the discussion we had on IRC, here are the correct routing keys. I've tested them via a durable queue for the past 15 hours, and I got exactly 2 messages. The first one points to [this task](https://tools.taskcluster.net/task-inspector/#EWFkjTdBQVeItFsGH8E4QA/), which looks promising 😃 

Thanks for the help @rail. r? 