### PR TITLE
Cannot find revision with new pulse routes

### DIFF
--- a/fennec_aurora_task_creator/exceptions.py
+++ b/fennec_aurora_task_creator/exceptions.py
@@ -13,9 +13,14 @@ class UnmatchedRouteError(Exception):
         super().__init__('No {} was found in the routes of: {}'.format(field_name, task_definition))
 
 
-class NotOnlyOneApkError(Exception):
+class NoApkFoundError(Exception):
+    def __init__(self, all_artifacts):
+        super().__init__('No APK matching regex found. Candidate artifacts were: {}'.format(all_artifacts))
+
+
+class MoreThanOneApkFoundError(Exception):
     def __init__(self, matched_artifacts):
-        super().__init__('Not only one artifact matches the APK regex. Matched artifacts: {}'.format(matched_artifacts))
+        super().__init__('More than one artifact matches the APK regex. Matched artifacts:: {}'.format(matched_artifacts))
 
 
 class TaskNotFoundError(Exception):

--- a/fennec_aurora_task_creator/tc_queue.py
+++ b/fennec_aurora_task_creator/tc_queue.py
@@ -29,10 +29,6 @@ def pluck_revision(route_pattern, task_definition):
     return _match_field_in_routes(route_pattern, task_definition, 'revision', 2)
 
 
-def pluck_architecture(route_pattern, task_definition):
-    return _match_field_in_routes(route_pattern, task_definition, 'architecture', 3)
-
-
 def _match_field_in_routes(route_pattern, task_definition, field_name, field_number):
     route_matcher = re.compile(_get_regex_pattern_from_string_pattern(route_pattern))
 

--- a/fennec_aurora_task_creator/test/test_tc_queue.py
+++ b/fennec_aurora_task_creator/test/test_tc_queue.py
@@ -1,7 +1,7 @@
 import pytest
 
-from fennec_aurora_task_creator.tc_queue import fetch_task_definition, pluck_architecture, pluck_repository, \
-    pluck_revision, _queue, fetch_artifacts_list, create_task, _get_regex_pattern_from_string_pattern
+from fennec_aurora_task_creator.tc_queue import fetch_task_definition, pluck_repository, pluck_revision, \
+    _queue, fetch_artifacts_list, create_task, _get_regex_pattern_from_string_pattern
 from fennec_aurora_task_creator.exceptions import UnmatchedRouteError
 
 ROUTE_PATTERN = 'gecko.v2.{repository}.revision.{revision}.mobile-l10n.{architecture}.multi'
@@ -34,16 +34,6 @@ def test_pluck_revision():
         # No revision
         pluck_repository(ROUTE_PATTERN, {
             'routes': ['index.gecko.v2.mozilla-aurora.latest.mobile-l10n.android-api-15-opt.multi']
-        })
-
-
-def test_pluck_architecture():
-    assert pluck_architecture(ROUTE_PATTERN, TASK_DEFINITION) == 'android-api-15-opt'
-
-    with pytest.raises(UnmatchedRouteError):
-        # Not mobile
-        pluck_repository(ROUTE_PATTERN, {
-            'routes': ['index.gecko.v2.mozilla-aurora.revision.7bc185ff4e8b66536bf314f9cf8b03f7d7f0b9b8.firefox.win32']
         })
 
 

--- a/fennec_aurora_task_creator/worker.py
+++ b/fennec_aurora_task_creator/worker.py
@@ -51,9 +51,10 @@ async def _dispatch(channel, body, envelope, _):
     config = get_config()
 
     try:
+        route_pattern = config['taskcluster_index_pattern']
         task_definition = tc_queue.fetch_task_definition(task_id)
-        revision = tc_queue.pluck_revision(task_definition)
-        repository = tc_queue.pluck_repository(task_definition)
+        revision = tc_queue.pluck_revision(route_pattern, task_definition)
+        repository = tc_queue.pluck_repository(route_pattern, task_definition)
 
         log.info('Processing revision "{}" from repository "{}" (triggered by completed task "{}")'.format(
             revision, repository, task_id


### PR DESCRIPTION
Follow up of #6. When I changed the pulse routing keys, I forgot to update the regex, which gave the logs below.

There are a couple of things wrong then:

1. The regex shouldn't be hardcoded anymore, of somebody changes the pulse routing keys. We should instead generate the regex from the one single point of configuration.
2. As the logs show, we dismiss the messages, even though they weren't correctly processed. 

This patch fixes both issues.

r? @rail 

```
2016-11-08T13:05:51.338215+00:00 app[worker.1]: 2016-11-08 13:05:51,337 - worker.py - ERROR - Exception "No revision was found in the routes of: {'metadata': {'description': 'Upload outputs of buildbot/mozharness builds to S3', 'owner': 'mshal@mozilla.com', 'source': 'http://hg.mozilla.org/build/mozharness/', 'name': 'Buildbot/mozharness S3 uploader'}, 'workerType': 'buildbot', 'provisionerId': 'null-provisioner', 'taskGroupId': 'CV_Hmd_nT5alu_URn58r6g', 'created': '2016-11-08T10:35:48.520Z', 'retries': 5, 'payload': {}, 'dependencies': [], 'deadline': '2016-11-08T11:35:48.520Z', 'priority': 'normal', 'extra': {'index': {'rank': 1478592764}}, 'scopes': [], 'routes': ['index.gecko.v2.mozilla-aurora.revision.d9cfe58247e85c05ad98a4e60045bbdd62e0ec2b.mobile-l10n.android-x86-opt.multi', 'index.gecko.v2.mozilla-aurora.pushdate.2016.11.08.20161108081244.mobile-l10n.android-x86-opt.multi', 'index.gecko.v2.mozilla-aurora.latest.mobile-l10n.android-x86-opt.multi', 'index.buildbot.branches.mozilla-aurora.android-x86', 'index.buildbot.revisions.d9cfe58247e85c05ad98a4e60045bbdd62e0ec2b.mozilla-aurora.android-x86'], 'expires': '2017-11-08T11:35:48.520Z', 'requires': 'all-completed', 'schedulerId': '-', 'tags': {}}" caught by generic exception trap

2016-11-08T13:05:51.338230+00:00 app[worker.1]: Traceback (most recent call last):

2016-11-08T13:05:51.338231+00:00 app[worker.1]:   File "/app/fennec_aurora_task_creator/worker.py", line 55, in _dispatch

2016-11-08T13:05:51.338232+00:00 app[worker.1]:     revision = tc_queue.pluck_revision(task_definition)

2016-11-08T13:05:51.338233+00:00 app[worker.1]:   File "/app/fennec_aurora_task_creator/tc_queue.py", line 29, in pluck_revision

2016-11-08T13:05:51.338234+00:00 app[worker.1]:     return _match_field_in_routes(task_definition, 'revision', 2)

2016-11-08T13:05:51.338234+00:00 app[worker.1]:   File "/app/fennec_aurora_task_creator/tc_queue.py", line 44, in _match_field_in_routes

2016-11-08T13:05:51.338235+00:00 app[worker.1]:     raise UnmatchedRouteError(field_name, task_definition)

2016-11-08T13:05:51.338241+00:00 app[worker.1]: fennec_aurora_task_creator.exceptions.UnmatchedRouteError: No revision was found in the routes of: {'metadata': {'description': 'Upload outputs of buildbot/mozharness builds to S3', 'owner': 'mshal@mozilla.com', 'source': 'http://hg.mozilla.org/build/mozharness/', 'name': 'Buildbot/mozharness S3 uploader'}, 'workerType': 'buildbot', 'provisionerId': 'null-provisioner', 'taskGroupId': 'CV_Hmd_nT5alu_URn58r6g', 'created': '2016-11-08T10:35:48.520Z', 'retries': 5, 'payload': {}, 'dependencies': [], 'deadline': '2016-11-08T11:35:48.520Z', 'priority': 'normal', 'extra': {'index': {'rank': 1478592764}}, 'scopes': [], 'routes': ['index.gecko.v2.mozilla-aurora.revision.d9cfe58247e85c05ad98a4e60045bbdd62e0ec2b.mobile-l10n.android-x86-opt.multi', 'index.gecko.v2.mozilla-aurora.pushdate.2016.11.08.20161108081244.mobile-l10n.android-x86-opt.multi', 'index.gecko.v2.mozilla-aurora.latest.mobile-l10n.android-x86-opt.multi', 'index.buildbot.branches.mozilla-aurora.android-x86', 'index.buildbot.revisions.d9cfe58247e85c05ad98a4e60045bbdd62e0ec2b.mozilla-aurora.android-x86'], 'expires': '2017-11-08T11:35:48.520Z', 'requires': 'all-completed', 'schedulerId': '-', 'tags': {}}

2016-11-08T13:05:51.338353+00:00 app[worker.1]: 2016-11-08 13:05:51,338 - worker.py - INFO - Marking message as read. Processed task "CV_Hmd_nT5alu_URn58r6g"
```