### PR TITLE
Make config.py convert integer values from environment

### DIFF
--- a/fennec_aurora_task_creator/config.py
+++ b/fennec_aurora_task_creator/config.py
@@ -157,10 +157,7 @@ def _get_environment_or_config_or_default_value(config_from_json_file, path_list
     if value is None:
         raise MissingConfigurationError(environment_key, '/'.join(path_list))
 
-    if isinstance(default_value, bool) and not isinstance(value, bool):
-        value = bool(strtobool(value))  # strtobool returns either 0 or 1
-
-    return value
+    return _convert_value_to_correct_type(value, default_value)
 
 
 def _set_dict_path(recursive_dictionary, path_list, value):
@@ -172,3 +169,12 @@ def _set_dict_path(recursive_dictionary, path_list, value):
 
 def _get_dict_path(dictionary, path_list):
     return dictionary[path_list[0]] if len(path_list) == 1 else _get_dict_path(dictionary[path_list[0]], path_list[1:])
+
+
+def _convert_value_to_correct_type(value, default_value=None):
+    type_of_default_value = type(default_value)
+    if default_value is not None and type(value) is not type_of_default_value:
+        # strtobool returns either 0 or 1, so we need to convert it back to bool, in order to be able to use conditions
+        # like `is True`
+        value = bool(strtobool(value)) if type_of_default_value is bool else type_of_default_value(value)
+    return value


### PR DESCRIPTION
2 days ago, I added the `TREEHERDER_TIER` env var to the Heroku instance. This made the job disappear from Treeherder[0]. After comparing a job before[1] and a job after[2] the change, it turns out the value became a string.

This patch makes sure the conversion is made based on the default value (if no default value, then no conversion). 

r? @rail 

[0] Last displayed job: https://treeherder.mozilla.org/#/jobs?repo=mozilla-aurora&filter-tier=3&filter-tier=2&filter-tier=1&filter-searchStr=gp&fromchange=7368fa4424f5a4340ed6d7818f99279e46978751&selectedJob=65822655 
[1] https://queue.taskcluster.net/v1/task/ES1Lzd-wS5yujvTmH-2Www
[2] https://queue.taskcluster.net/v1/task/PrSrDX8vQJmh7MSj8syITQ